### PR TITLE
Support additional MOD formats

### DIFF
--- a/js/player.js
+++ b/js/player.js
@@ -34,6 +34,7 @@ function Modplayer()
   this.onReady=function(){};
   this.onPlay=function(){};
   this.onStop=function(){};
+  this.onMix=function(){};
 
   this.buffer=0;
   this.mixerNode=0;
@@ -316,7 +317,16 @@ Modplayer.prototype.patterndata = function(pn)
 {
   var i, c, patt;
   if (this.format=='mod') {
-    patt=new Uint8Array(this.player.pattern_unpack[pn]);
+    if (this.player.track_index) {
+        patt = new Uint8Array(64*this.player.channels*5);
+        for(i=0;i<64;i++) for(c=0;c<this.player.channels;c++) {
+            var p = this.player.track_index[pn*this.player.channels*2+c*2];
+            for (var d=0; d<5; d++)
+                patt[i*5*this.player.channels+c*5+d] = this.player.pattern_unpack[p][i*5+d];
+        }
+    } else {
+        patt=new Uint8Array(this.player.pattern_unpack[this.player.patterntable[pn]]);
+    }
     for(i=0;i<64;i++) for(c=0;c<this.player.channels;c++) {
       if (patt[i*5*this.channels+c*5+3]==0 && patt[i*5*this.channels+c*5+4]==0) {
         patt[i*5*this.channels+c*5+3]=0x2e;
@@ -410,7 +420,7 @@ Modplayer.prototype.createContext = function()
     this.mixerNode=this.context.createScriptProcessor(this.bufferlen, 1, 2);
   }
   this.mixerNode.module=this;
-  this.mixerNode.onaudioprocess=Modplayer.prototype.mix;
+  this.mixerNode.onaudioprocess=Modplayer.prototype.mix.bind(this);
 
   // patch up some cables :)
   this.mixerNode.connect(this.filterNode);
@@ -485,5 +495,6 @@ Modplayer.prototype.mix = function(ape) {
     }
   }
 
+  this.onMix();
 
 }

--- a/js/pt.js
+++ b/js/pt.js
@@ -107,6 +107,7 @@ Protracker.prototype.clearsong = function()
   this.pattern=new Array();
   this.note=new Array();
   this.pattern_unpack=new Array();
+  this.track_index=null;
 
   this.looprow=0;
   this.loopstart=0;
@@ -193,7 +194,11 @@ Protracker.prototype.parse = function(buffer)
 
     default:
       this.signature = "";
-      this.samples = 15;
+      for(i=0;i<4;i++) this.signature+=String.fromCharCode(buffer[952+i]);
+      if (this.signature != "KRIS") {
+        this.signature = "";
+        this.samples = 15;
+      }
   }
   this.chvu=new Array();
   for(i=0;i<this.channels;i++) this.chvu[i]=0.0;
@@ -202,7 +207,7 @@ Protracker.prototype.parse = function(buffer)
   while(buffer[i] && i<20)
     this.title=this.title+String.fromCharCode(buffer[i++]);
 
-  var bufp = 20;
+  var bufp = 20 + (this.signature === "KRIS" ? 2 : 0);
   for(i=0;i<this.samples;i++) {
     var st=bufp+i*30;
     j=0;
@@ -226,43 +231,87 @@ Protracker.prototype.parse = function(buffer)
     }
   }
 
-  bufp += 30*this.samples;
+  bufp += 30*this.samples + (this.signature === "KRIS" ? 4 : 0);
   this.songlen=buffer[bufp];
   if (buffer[bufp+1] != 127) this.repeatpos=buffer[bufp+1];
   bufp += 2;
-  for(i=0;i<128;i++) {
-    this.patterntable[i]=buffer[bufp+i];
-    if (this.patterntable[i] > this.patterns) this.patterns=this.patterntable[i];
-  }
-  this.patterns+=1;
-  var patlen=4*64*this.channels;
 
-  bufp += 128 + (this.samples===15 ? 0 : 4);
-  this.pattern=new Array();
-  this.note=new Array();
-  this.pattern_unpack=new Array();
-  for(i=0;i<this.patterns;i++) {
-    this.pattern[i]=new Uint8Array(patlen);
-    this.note[i]=new Uint8Array(this.channels*64);
-    this.pattern_unpack[i]=new Uint8Array(this.channels*64*5);
-    for(j=0;j<patlen;j++) this.pattern[i][j]=buffer[bufp+i*patlen+j];
-    for(j=0;j<64;j++) for(c=0;c<this.channels;c++) {
-      this.note[i][j*this.channels+c]=0;
-      var n=(this.pattern[i][j*4*this.channels+c*4]&0x0f)<<8 | this.pattern[i][j*4*this.channels+c*4+1];
-      for(var np=0; np<this.baseperiodtable.length; np++)
-        if (n==this.baseperiodtable[np]) this.note[i][j*this.channels+c]=np;
+  if (this.signature != "KRIS") {
+    for(i=0;i<128;i++) {
+      this.patterntable[i]=buffer[bufp+i];
+      if (this.patterntable[i] > this.patterns) this.patterns=this.patterntable[i];
     }
-    for(j=0;j<64;j++) {
-      for(c=0;c<this.channels;c++) {
-        var pp= j*4*this.channels+c*4;
-        var ppu=j*5*this.channels+c*5;
-        var n=(this.pattern[i][pp]&0x0f)<<8 | this.pattern[i][pp+1];
-        if (n) { n=this.note[i][j*this.channels+c]; n=(n%12)|(Math.floor(n/12)+2)<<4; }
-        this.pattern_unpack[i][ppu+0]=(n)?n:255;
-        this.pattern_unpack[i][ppu+1]=this.pattern[i][pp+0]&0xf0 | this.pattern[i][pp+2]>>4;
-        this.pattern_unpack[i][ppu+2]=255;
-        this.pattern_unpack[i][ppu+3]=this.pattern[i][pp+2]&0x0f;
-        this.pattern_unpack[i][ppu+4]=this.pattern[i][pp+3];
+    this.patterns+=1;
+    var patlen=4*64*this.channels;
+
+    bufp += 128 + (this.samples===15 ? 0 : 4);
+    this.pattern=new Array();
+    this.note=new Array();
+    this.pattern_unpack=new Array();
+    for(i=0;i<this.patterns;i++) {
+      this.pattern[i]=new Uint8Array(patlen);
+      this.note[i]=new Uint8Array(this.channels*64);
+      this.pattern_unpack[i]=new Uint8Array(this.channels*64*5);
+      for(j=0;j<patlen;j++) this.pattern[i][j]=buffer[bufp+i*patlen+j];
+      for(j=0;j<64;j++) for(c=0;c<this.channels;c++) {
+        this.note[i][j*this.channels+c]=0;
+        var n=(this.pattern[i][j*4*this.channels+c*4]&0x0f)<<8 | this.pattern[i][j*4*this.channels+c*4+1];
+        for(var np=0; np<this.baseperiodtable.length; np++)
+          if (n==this.baseperiodtable[np]) this.note[i][j*this.channels+c]=np;
+      }
+      for(j=0;j<64;j++) {
+        for(c=0;c<this.channels;c++) {
+          var pp= j*4*this.channels+c*4;
+          var ppu=j*5*this.channels+c*5;
+          var n=(this.pattern[i][pp]&0x0f)<<8 | this.pattern[i][pp+1];
+          if (n) { n=this.note[i][j*this.channels+c]; n=(n%12)|(Math.floor(n/12)+2)<<4; }
+          this.pattern_unpack[i][ppu+0]=(n)?n:255;
+          this.pattern_unpack[i][ppu+1]=this.pattern[i][pp+0]&0xf0 | this.pattern[i][pp+2]>>4;
+          this.pattern_unpack[i][ppu+2]=255;
+          this.pattern_unpack[i][ppu+3]=this.pattern[i][pp+2]&0x0f;
+          this.pattern_unpack[i][ppu+4]=this.pattern[i][pp+3];
+        }
+      }
+    }
+  } else {
+    this.track_index = buffer.slice(bufp, bufp + 128*this.channels*2);
+
+    for(i = 0; i < 128; i++) {
+      for(c = 0; c < this.channels; c++) {
+        if (this.track_index[2*this.channels*i+2*c] > this.patterns)
+          this.patterns = this.track_index[2*this.channels*i+2*c];
+      }
+    }
+    this.patterns += 1;
+    patlen = 4*64;
+
+    bufp += 2+this.track_index.length;
+    this.pattern=new Array();
+    this.note=new Array();
+    this.pattern_unpack=new Array();
+    for(i=0;i<this.patterns;i++) {
+      var ps = bufp + i*patlen;
+      this.pattern[i] = buffer.slice(ps, ps+patlen);
+      this.note[i]=new Uint8Array(64);
+      this.pattern_unpack[i]=new Uint8Array(64*5);
+      for(j=0;j<64;j++) {
+        var np = this.pattern[i][4*j]/2 - 36;
+        this.note[i][j] = (np >= 0 && np < this.baseperiodtable.length) ? np : 0;
+      }
+      for(j=0;j<64;j++) {
+          var pp=j*4;
+          var ppu=j*5;
+          var n = this.baseperiodtable[this.pattern[i][pp]/2-36];
+          if (n) { nn=this.note[i][j]; nn=(nn%12)|(Math.floor(nn/12)+2)<<4; }
+          this.pattern_unpack[i][ppu+0]=(nn)?nn:255;
+          this.pattern_unpack[i][ppu+1]=this.pattern[i][pp+1];
+          this.pattern_unpack[i][ppu+2]=255;
+          this.pattern_unpack[i][ppu+3]=this.pattern[i][pp+2]&0x0f;
+          this.pattern_unpack[i][ppu+4]=this.pattern[i][pp+3];
+          nn = this.pattern[i][pp+1];
+          this.pattern[i][pp+0] = (n>>8)&0x0f || nn&0xf0;
+          this.pattern[i][pp+1] = n&0xff;
+          this.pattern[i][pp+2] = (nn&0xf)<<4 | this.pattern[i][pp+2]&0xf;
       }
     }
   }
@@ -387,8 +436,13 @@ Protracker.prototype.mix = function(mod, bufs, buflen) {
       {
 
         // calculate playback position
-        p=mod.patterntable[mod.position];
-        pp=mod.row*4*mod.channels + ch*4;
+        if (!this.track_index) {
+          p=mod.patterntable[mod.position];
+          pp=mod.row*4*mod.channels + ch*4;
+        } else {
+          p = mod.track_index[mod.position*mod.channels*2 + ch*2];
+          pp = mod.row*4;
+        }
         if (mod.flags&2) { // new row
           mod.channel[ch].command=mod.pattern[p][pp+2]&0x0f;
           mod.channel[ch].data=mod.pattern[p][pp+3];

--- a/js/ui.js
+++ b/js/ui.js
@@ -253,11 +253,11 @@ function updateUI(timestamp)
       $("#odd-channels").html(txt1);
     } else if (window.moduleVis==1) {
       if (oldpos>=0 && oldrow>=0) $(".currentrow").removeClass("currentrow");
-      $("#pattern"+hb(mod.currentpattern())+"_row"+hb(mod.row)).addClass("currentrow");
-      $("#pattern"+hb(mod.currentpattern())).scrollTop(mod.row*16);
+      $("#pattern"+hb(mod.position)+"_row"+hb(mod.row)).addClass("currentrow");
+      $("#pattern"+hb(mod.position)).scrollTop(mod.row*16);
       if (oldpos != mod.position) {
         if (oldpos>=0) $(".currentpattern").removeClass("currentpattern");
-        $("#pattern"+hb(mod.currentpattern())).addClass("currentpattern");
+        $("#pattern"+hb(mod.position)).addClass("currentpattern");
       }
     }
 
@@ -354,10 +354,12 @@ $(document).ready(function() {
     var s=window.currentModule.split("/");
     if (s.length > 1) {
       $("title").html(s[1]+" - module player for Web Audio");
-      window.history.pushState("object of string", "Title", "/"+s[0]+"/"+s[1]);
+      if (window.location.protocol !== "file:")
+        window.history.pushState("object of string", "Title", "/"+s[0]+"/"+s[1]);
     } else {
       $("title").html(s[0]+" - module player for Web Audio");
-      window.history.pushState("object of string", "Title", "/"+s[0]);
+      if (window.location.protocol !== "file:")
+        window.history.pushState("object of string", "Title", "/"+s[0]);
     }
 
     if (window.playlistActive) {
@@ -369,7 +371,7 @@ $(document).ready(function() {
     }
 
     var pd="";
-    for(p=0;p<this.patterns;p++) {
+    for(p=0;p<this.songlen;p++) {
       var pp, pdata;
       pd+="<div class=\"patterndata\" id=\"pattern"+hb(p)+"\">";
       for(i=0; i<12; i++) pd+="\n";
@@ -503,6 +505,7 @@ $(document).ready(function() {
     $("#modfile").focus();
     var s=document.getElementById("modfile");
     var i=s.selectedIndex;
+    if (!s[i]) return;
     s[i].selected=false;
     s[(i<(s.length-12))?(i+12):(s.length-1)].selected=true;
     s[i].selected=true;


### PR DESCRIPTION
### Add additional MOD format support

The classic MOD format is quite straightforward - file has no header and only 15 samples.
As a result, the data offsets are changed. Examples:
- https://www.exotica.org.uk/wiki/Prehistorik
- https://www.exotica.org.uk/wiki/Titus_the_Fox

The Chiptracker MOD is more complex.
It used patterns per track, so the pattern structures are different. The adapted UI now shows data per song position, not per pattern number.
Also the 4-byte event encoding is much simpler, but on loading it gets encoded back to avoid major rework. Still it contains the same information.
Some resources about this format:
- http://www.pouet.net/prod.php?which=29988
- https://github.com/libxmp/libxmp/blob/master/src/loaders/chip_load.c
- https://www.exotica.org.uk/wiki/Dojo_Dan
